### PR TITLE
attach to naptime skill

### DIFF
--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -18,3 +18,7 @@ skillMetadata:
           label: Day
           value: ""
           placeholder: 16
+        - name: attach_to_naptime
+          type: checkbox
+          label: Attach to Naptime skill
+          value: "false"


### PR DESCRIPTION
This is a PR for my [suggestion](https://github.com/rekkitcwts/sleep-tracker-skill/issues/1) to add support for naptime skill.

A new setting "Attach to naptime skill" is available in the skill settings. When checked, the sleep tracker will attach to the message bus events "sleep" and "awoken" that are emitted by the naptime skill. By this the sleep tracker will automatically track your sleep when you tell Mycroft to go to sleep/wake up.